### PR TITLE
Create IdCard/Door & IdCard/CardReader Combination

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 [![Build Status](https://travis-ci.org/mkli90/tekmate.svg?branch=master)](https://travis-ci.org/mkli90/tekmate)
 [![Code Health](https://landscape.io/github/mkli90/tekmate/master/landscape.svg?style=flat)](https://landscape.io/github/mkli90/tekmate/master)
+[![Coverage Status](https://coveralls.io/repos/mkli90/tekmate/badge.svg)](https://coveralls.io/r/mkli90/tekmate)

--- a/tekmate/game.py
+++ b/tekmate/game.py
@@ -84,3 +84,42 @@ class Key(Item):
     def get_name(self):
         return "Key"
 
+
+class IdCard(Item):
+    class AccessDenied(Exception):
+        pass
+
+    def setup(self):
+        self.unique_attributes["key_code"] = 0
+
+    def get_name(self):
+        return "ID-Card"
+
+    def combine_with(self, other):
+        if self.has_insufficient_permissions(other):
+            raise IdCard.AccessDenied
+        other.usable = True
+
+    def has_insufficient_permissions(self, other):
+        return other.unique_attributes["access_code"] != self.unique_attributes["key_code"]
+
+
+class Door(Item):
+    def setup(self):
+        self.unique_attributes["access_code"] = 0
+
+    def get_name(self):
+        return "Door"
+
+
+class CardReader(Item):
+    class NotAnIdCard(Exception):
+        pass
+
+    def get_name(self):
+        return "Card-Reader"
+
+    def combine_with(self, other):
+        if other.get_name() != "ID-Card":
+            raise CardReader.NotAnIdCard
+        other.unique_attributes["key_code"] += 1

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -3,7 +3,7 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from tekmate.game import Player, Item, Needle, Key, Lock
+from tekmate.game import Player, Item, Needle, Key, Lock, IdCard, Door, CardReader
 
 
 class PlayerTestCase(TestCase):
@@ -109,4 +109,51 @@ class NeedleTestCase(TestCase):
         self.needle.combine(self.lock)
         self.assertTrue(self.key.obtainable)
 
+
+class IdCardTestCase(TestCase):
+    def setUp(self):
+        self.idcard = IdCard([])
+        self.door = Door([])
+
+    def test_can_create_id_card(self):
+        self.assertEqual("ID-Card", self.idcard.get_name())
+
+    def test_key_code_is_defaulted_at_zero(self):
+        self.assertEqual(0, self.idcard.unique_attributes["key_code"])
+
+    def test_id_card_can_open_door(self):
+        self.idcard.combine(self.door)
+        self.assertTrue(self.door.usable)
+
+    def test_when_combined_with_door_and_insufficient_permissions_raise_Access_Denied(self):
+        self.door.unique_attributes["access_code"] = 1
+        self.assertRaises(IdCard.AccessDenied, self.idcard.combine, self.door)
+
+
+class DoorTestCase(TestCase):
+    def setUp(self):
+        self.door = Door([])
+
+    def test_can_create_door(self):
+        self.assertEqual("Door", self.door.get_name())
+
+    def test_access_code_is_defaulted_at_zero(self):
+        self.assertEqual(0, self.door.unique_attributes["access_code"])
+
+
+class CardReaderTestCase(TestCase):
+    def setUp(self):
+        self.reader = CardReader([])
+
+    def test_can_create_card_reader(self):
+        self.assertEqual("Card-Reader", self.reader.get_name())
+
+    def test_when_combined_with_card_reader_increase_key_code(self):
+        idcard = IdCard([])
+        self.reader.combine(idcard)
+        self.assertEqual(idcard.unique_attributes["key_code"], 1)
+
+    def test_when_combined_with_other_than_a_card_raise_exception(self):
+        any_item = Item([])
+        self.assertRaises(CardReader.NotAnIdCard, self.reader.combine, any_item)
 


### PR DESCRIPTION
id-card can be combined with door
 - id-card needs sufficient permissions
 - permissions are reperesented as "key_code" for the idcard and "access_code" for the door
 - if insufficient persmisions then AccessDenied is thrown

id-card can be combined with cardreader
 - id-card's key_code is incremented on combination
 - cardreader throws exception when not combined with id-card