### PR TITLE
#34, #35, #37 - renamed add_to_container, removed combine_with, item appends to parent_container

### DIFF
--- a/tekmate/items.py
+++ b/tekmate/items.py
@@ -13,6 +13,7 @@ class Item(object):
 
     def __init__(self, parent_container):
         assert parent_container is not None
+        parent_container.append(self)
         self.usable = False
         self.obtainable = False
         self.parent_container = parent_container
@@ -23,16 +24,13 @@ class Item(object):
     def setup(self):  # pragma: no cover
         pass
 
-    def combine(self, other):
-        self.combine_with(other)
-
-    def combine_with(self, other):  # pragma: no cover
+    def combine(self, other):  # pragma: no cover
         pass
 
     def remove_from_parent_container(self):
         self.parent_container.remove(self)
 
-    def add_to_container(self, new_container):
+    def move_to_container(self, new_container):
         new_container.append(self)
         self.remove_from_parent_container()
         self.parent_container = new_container
@@ -56,7 +54,7 @@ class Needle(Item):
     def get_name(self):
         return "Needle"
 
-    def combine_with(self, other):
+    def combine(self, other):
         if other.get_name() != "Lock":
             raise Item.InvalidCombination
         self.remove_from_parent_container()
@@ -85,7 +83,7 @@ class IdCard(Item):
     def get_name(self):
         return "ID-Card"
 
-    def combine_with(self, other):
+    def combine(self, other):
         if self.has_insufficient_permissions(other):
             raise IdCard.AccessDenied
         other.usable = True
@@ -109,7 +107,7 @@ class CardReader(Item):
     def get_name(self):
         return "Card-Reader"
 
-    def combine_with(self, other):
+    def combine(self, other):
         if other.get_name() != "ID-Card":
             raise CardReader.NotAnIdCard
         other.unique_attributes["key_code"] += 1
@@ -127,7 +125,7 @@ class Note(Item):
     def get_name(self):
         return "Note"
 
-    def combine_with(self, other):
+    def combine(self, other):
         if other.get_name() != "Symbols-Folder":
             raise Item.InvalidCombination
 
@@ -155,7 +153,7 @@ class Telephone(Item):
     def get_name(self):
         return "Telephone"
 
-    def combine_with(self, other):
+    def combine(self, other):
         if other.get_name() != "Telephone-Note":
             raise Item.InvalidCombination
         other.remove_from_parent_container()
@@ -168,10 +166,10 @@ class Flyer(Item):
     def get_name(self):
         return "Flyer"
 
-    def combine_with(self, other):
+    def combine(self, other):
         if other.get_name() != "Door":
             raise Item.InvalidCombination
         key = next(item for item in other.parent_container if item.get_name() == "Key")
         if not key.obtainable:
             raise Key.NotObtainable
-        key.add_to_container(self.parent_container)
+        key.move_to_container(self.parent_container)

--- a/tekmate/ui.py
+++ b/tekmate/ui.py
@@ -26,7 +26,7 @@ class PlayerUserInterface(object):
         self.surface.fill((255, 255, 255))
         self.surface.blit(self.image, (0, 0))
 
-    def draw_player_to_display(self, display):  # pragma: no cover
+    def draw_player_to_display(self, display):
         display.blit(self.surface, self.get_position())
 
     def create_surface_and_image(self, factor):

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -10,10 +10,12 @@ class ItemTestCase(TestCase):
     def setUp(self):
         self.container = []
         self.item = Item(self.container)
-        self.container.append(self.item)
 
     def test_can_create_item(self):
         self.assertEqual("Item", self.item.get_name())
+
+    def test_when_created_item_should_be_inside_parent_container(self):
+        self.assertIn(self.item, self.item.parent_container)
 
     def test_not_obtainable_by_default(self):
         self.assertFalse(self.item.obtainable)
@@ -33,7 +35,7 @@ class ItemTestCase(TestCase):
                 super(MockItem, self).__init__(parent_container)
                 self.called = False
 
-            def combine_with(self, other):
+            def combine(self, other):
                 self.called = other is item
 
         mock_item = MockItem([])
@@ -46,7 +48,7 @@ class ItemTestCase(TestCase):
 
     def test_when_add_to_container_container_should_change(self):
         container_new = []
-        self.item.add_to_container(container_new)
+        self.item.move_to_container(container_new)
         self.assertIn(self.item, container_new)
         self.assertNotIn(self.item, self.container)
 
@@ -60,13 +62,6 @@ class NeedleTestCase(TestCase):
         self.needle = Needle(self.container)
         self.key = Key(self.world_container)
         self.lock = Lock(self.world_container)
-
-        self.append_items_to_respective_containers()
-
-    def append_items_to_respective_containers(self):
-        self.container.append(self.needle)
-        self.world_container.append(self.key)
-        self.world_container.append(self.lock)
 
     def test_can_create_needle(self):
         self.assertEqual("Needle", self.needle.get_name())
@@ -138,7 +133,6 @@ class NoteTestCase(TestCase):
         self.folder = SymbolsFolder([])
         self.player = Player()
         self.note = Note(self.player.bag)
-        self.player.add_item(self.note)
 
     def test_can_create_note(self):
         self.assertEqual("Note", self.note.get_name())
@@ -164,7 +158,6 @@ class TelephoneTestCase(TestCase):
     def setup_player_bag(self):
         self.player = Player()
         self.tel_note = TelephoneNote(self.player.bag)
-        self.player.add_item(self.tel_note)
 
     def test_can_create_telephone(self):
         self.assertEqual(self.telephone.get_name(), "Telephone")

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 from unittest import TestCase, skip
 
-from mock import patch, call
+from mock import patch, call, Mock
 import pygame
 
 from tekmate.game import Player
@@ -44,11 +44,10 @@ class PlayerUITestCase(TestCase):
         expected_argument_for_blit = call(self.player_ui.image, (0, 0))
         self.assertBlitArgumentIs(expected_argument_for_blit)
 
-    @skip("What has to be tested here?")
     def test_when_drawn_player_to_display_expected_argument_should_be_display(self):
-        display = pygame.display.get_surface()
-        self.assertEqual(self.player_ui.draw_player_to_display(display), display)
-
+        mock_display = Mock()
+        self.player_ui.draw_player_to_display(mock_display)
+        mock_display.blit.assert_called_with(self.player_ui.surface, (0, 0))
 
     def assertBlitArgumentIs(self, expected_args):
         returned_argument_list_for_blit = self.player_ui.surface.blit.call_args_list


### PR DESCRIPTION
- #37 - The "add_to_container" function has been renamed to
"move_to_container"
- #35 - Item no longer has a "combine_with" delegate.
- #34 - Every Item appends itself to the parent_container upon
  creation. That allows to get rid off all the container.append() after
  changing the parent_container
- Unittest-Fix in test_ui.py - The skipped test is now correctly testing
  the behaviour of draw_player_to_display