### PR TITLE
-#19 -Item-Item Interaction: Key/Door

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@
 [![Code Health](https://landscape.io/github/mkli90/tekmate/master/landscape.svg?style=flat)](https://landscape.io/github/mkli90/tekmate/master)
 [![Coverage Status](https://coveralls.io/repos/mkli90/tekmate/badge.svg)](https://coveralls.io/r/mkli90/tekmate)
 
+
+##Planning:
+-Items in bag shall never be used, one can only combine them with items in the world/bag.
+-One should always write out the combine-function in the "bag-item"

--- a/tekmate/items.py
+++ b/tekmate/items.py
@@ -71,6 +71,11 @@ class Key(Item):
     def get_name(self):
         return "Key"
 
+    def combine(self, other):
+        if not other.get_name() == "Door":
+            raise self.InvalidCombination
+        other.usable = True
+
 
 class IdCard(Item):
     class AccessDenied(Exception):

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -177,11 +177,8 @@ class FlyerTestCase(TestCase):
         self.world_container = []
         self.key = Key(self.world_container)
         self.door = Door(self.world_container)
-        self.append_items_to_world_container()
 
-    def append_items_to_world_container(self):
-        self.world_container.append(self.key)
-        self.world_container.append(self.door)
+    #TODO: add to commit message: deleted testcase
 
     def test_can_create_flyer(self):
         self.assertEqual(self.flyer.get_name(), "Flyer")
@@ -200,3 +197,19 @@ class FlyerTestCase(TestCase):
         self.flyer.combine(self.door)
         self.assertIn(self.key, player.bag)
 
+
+class KeyTestCase(TestCase):
+    def setUp(self):
+        self.key = Key([])
+
+    def test_can_create_key(self):
+        self.assertIsInstance(self.key, Key)
+
+    def test_when_key_combined_other_than_door_raise_exception(self):
+        any_item = Item([])
+        self.assertRaises(Item.InvalidCombination, self.key.combine, any_item)
+
+    def test_when_key_combined_with_door_and_door_not_usable_make_it_usable(self):
+        door = Door([])
+        self.key.combine(door)
+        self.assertEqual(door.usable, True)


### PR DESCRIPTION
-#19 Combining key with door now makes the door usable. The logic behind
the door behavior should not be in door or in key, because door only
returns the "usable"-status of itself. Retruning a string turned out as a
hole new issue, so this is not yet done.