### PR TITLE
#41 Define Call-Hierarchy of Letter/paperclip/Door

### DIFF
--- a/tekmate/items.py
+++ b/tekmate/items.py
@@ -11,6 +11,9 @@ class Item(object):
     class InvalidCombination(Exception):
         pass
 
+    class ConditionNotMet(Exception):
+        pass
+
     def __init__(self, parent_container):
         assert parent_container is not None
         parent_container.append(self)
@@ -18,6 +21,7 @@ class Item(object):
         self.obtainable = False
         self.parent_container = parent_container
         self.name = "Item"
+        self.looked_at = False
         self.unique_attributes = {}
         self.setup()
 
@@ -50,21 +54,20 @@ class Item(object):
         return "This is the Item-Description"
 
 
-class Needle(Item):
+class Paperclip(Item):
     def get_name(self):
-        return "Needle"
+        return "Paperclip"
 
     def combine(self, other):
-        if other.get_name() != "Lock":
+        if other.get_name() != "Door":
             raise Item.InvalidCombination
+        if not other.unique_attributes["combined_with_letter"]:
+            raise Item.ConditionNotMet
         self.remove_from_parent_container()
         key_item = next((item for item in other.parent_container if item.get_name() == "Key"))
         key_item.obtainable = True
+        other.unique_attributes["combined_with_paperclip"] = True
 
-
-class Lock(Item):
-    def get_name(self):
-        return "Lock"
 
 
 class Key(Item):
@@ -75,6 +78,7 @@ class Key(Item):
         if not other.get_name() == "Door":
             raise self.InvalidCombination
         other.usable = True
+        self.remove_from_parent_container()
 
 
 class IdCard(Item):
@@ -100,6 +104,7 @@ class IdCard(Item):
 class Door(Item):
     def setup(self):
         self.unique_attributes["access_code"] = 0
+        self.unique_attributes["combined_with_letter"] = False
 
     def get_name(self):
         return "Door"
@@ -164,17 +169,18 @@ class Telephone(Item):
         other.remove_from_parent_container()
 
 
-class Flyer(Item):
+class Letter(Item):
     def setup(self):
         self.obtainable = True
 
     def get_name(self):
-        return "Flyer"
+        return "Letter"
 
     def combine(self, other):
         if other.get_name() != "Door":
             raise Item.InvalidCombination
-        key = next(item for item in other.parent_container if item.get_name() == "Key")
-        if not key.obtainable:
-            raise Key.NotObtainable
-        key.move_to_container(self.parent_container)
+        if not other.looked_at:
+            raise Item.ConditionNotMet
+        self.remove_from_parent_container()
+        other.unique_attributes["combined_with_letter"] = True
+

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -2,8 +2,8 @@
 from unittest import TestCase
 
 from tekmate.game import Player
-from tekmate.items import Item, Needle, Lock, Key, IdCard, Door, CardReader, Note, SymbolsFolder, TelephoneNote, \
-    Telephone, Flyer
+from tekmate.items import Item, Key, IdCard, Door, CardReader, Note, SymbolsFolder, TelephoneNote, \
+    Telephone, Paperclip, Letter
 
 
 class ItemTestCase(TestCase):
@@ -22,6 +22,11 @@ class ItemTestCase(TestCase):
 
     def test_not_usable_by_default(self):
         self.assertFalse(self.item.usable)
+
+    def test_looked_at_door_variable_status(self):
+        self.assertEqual(self.item.looked_at, False)
+        self.item.looked_at = True
+        self.assertEqual(self.item.looked_at, True)
 
     def test_when_parent_container_is_none_AssertionError_is_raised(self):
         with self.assertRaises(AssertionError):
@@ -53,32 +58,39 @@ class ItemTestCase(TestCase):
         self.assertNotIn(self.item, self.container)
 
 
-class NeedleTestCase(TestCase):
+class PaperclipTestCase(TestCase):
 
     def setUp(self):
         self.container = []
         self.world_container = []
-
-        self.needle = Needle(self.container)
+        self.paperclip = Paperclip(self.container)
         self.key = Key(self.world_container)
-        self.lock = Lock(self.world_container)
+        self.door = Door(self.world_container)
+        self.door.unique_attributes["combined_with_letter"] = True
 
-    def test_can_create_needle(self):
-        self.assertEqual("Needle", self.needle.get_name())
+    def test_can_create_paperclip(self):
+        self.assertEqual("Paperclip", self.paperclip.get_name())
 
-    def test_when_combined_with_not_a_lock_raise_invalid_combination(self):
+    def test_when_combined_with_other_than_door_raise_invalid_combination(self):
         obj = Item([])
         with self.assertRaises(Item.InvalidCombination):
-            self.needle.combine(obj)
+            self.paperclip.combine(obj)
 
-    def test_gets_consumed_when_combined_correctly(self):
-        self.needle.combine(self.lock)
-        self.assertNotIn(self.needle, self.container)
+    def test_gets_consumed_when_combined_correctly_with_door(self):
+        self.paperclip.combine(self.door)
+        self.assertNotIn(self.paperclip, self.container)
 
     def test_when_combined_correctly_key_is_obtainable(self):
-        self.needle.combine(self.lock)
+        self.paperclip.combine(self.door)
         self.assertTrue(self.key.obtainable)
 
+    def test_when_combining_with_door_and_doors_combined_with_letter_is_false_raise_exception(self):
+        self.door.unique_attributes["combined_with_letter"] = False
+        self.assertRaises(Item.ConditionNotMet, self.paperclip.combine, self.door)
+
+    def test_when_combined_with_door_correctly_set_combined_with_paperclip_True(self):
+        self.paperclip.combine(self.door)
+        self.assertTrue(self.door.unique_attributes["combined_with_paperclip"])
 
 class IdCardTestCase(TestCase):
     def setUp(self):
@@ -109,6 +121,7 @@ class DoorTestCase(TestCase):
 
     def test_access_code_is_defaulted_at_zero(self):
         self.assertEqual(0, self.door.unique_attributes["access_code"])
+
 
 
 class CardReaderTestCase(TestCase):
@@ -171,36 +184,41 @@ class TelephoneTestCase(TestCase):
         self.assertNotIn(self.tel_note, self.player.bag)
 
 
-class FlyerTestCase(TestCase):
+class LetterTestCase(TestCase):
     def setUp(self):
-        self.flyer = Flyer([])
+        self.container = []
+        self.letter = Letter(self.container)
         self.world_container = []
         self.key = Key(self.world_container)
         self.door = Door(self.world_container)
 
-    #TODO: add to commit message: deleted testcase
+    def test_can_create_letter(self):
+        self.assertEqual(self.letter.get_name(), "Letter")
 
-    def test_can_create_flyer(self):
-        self.assertEqual(self.flyer.get_name(), "Flyer")
-
-    def test_when_flyer_combined_other_than_door_raise_exception(self):
+    def test_when_letter_combined_other_than_door_raise_exception(self):
         any_item = Item([])
-        self.assertRaises(Item.InvalidCombination, self.flyer.combine, any_item)
+        self.assertRaises(Item.InvalidCombination, self.letter.combine, any_item)
 
-    def test_when_flyer_combined_with_door_and_key_not_obtainable_raise_exception(self):
-        self.assertRaises(Key.NotObtainable, self.flyer.combine, self.door)
+    def test_gets_consumed_when_combined_correctly_with_door(self):
+        self.door.looked_at = True
+        self.letter.combine(self.door)
+        self.assertNotIn(self.letter, self.container)
 
-    def test_when_flyer_combined_with_door_and_key_obtainable_move_key_in_player_bag(self):
-        player = Player()
-        player.add_item(self.flyer)
-        self.key.obtainable = True
-        self.flyer.combine(self.door)
-        self.assertIn(self.key, player.bag)
+    def test_when_letter_combined_with_door_and_door_looked_at_is_false_raise_exception(self):
+        self.assertRaises(Item.ConditionNotMet, self.letter.combine, self.door)
+
+    def test_doors_combined_with_letter(self):
+        self.assertFalse(self.door.unique_attributes["combined_with_letter"])
+        self.door.looked_at = True
+        self.letter.combine(self.door)
+        self.assertTrue(self.door.unique_attributes["combined_with_letter"])
 
 
 class KeyTestCase(TestCase):
     def setUp(self):
-        self.key = Key([])
+        self.container = []
+        self.key = Key(self.container)
+        self.door = Door([])
 
     def test_can_create_key(self):
         self.assertIsInstance(self.key, Key)
@@ -210,6 +228,12 @@ class KeyTestCase(TestCase):
         self.assertRaises(Item.InvalidCombination, self.key.combine, any_item)
 
     def test_when_key_combined_with_door_and_door_not_usable_make_it_usable(self):
-        door = Door([])
-        self.key.combine(door)
-        self.assertEqual(door.usable, True)
+        self.key.combine(self.door)
+        self.assertEqual(self.door.usable, True)
+
+    def test_gets_consumed_when_combined_correctly_with_door(self):
+        self.door.unique_attributes["combined_with_paperclip"] = True
+        self.key.combine(self.door)
+        self.assertNotIn(self.key, self.container)
+
+


### PR DESCRIPTION
-#41 renamed Needle to Paperclip and Flyer to Letter. Deleted Lock.
Item.looked_at added to perform different actions depending on the
looked_at value (it is boolean).
made sure that the item combination order is correct: Look at door =>
combine letter with door => combine paperclip with door => obtainable key
=> picked up key can make the door usable.
Every Item will get consumed after combining.