### PR TITLE
#31 - Added some more features of the UI. Right-Click opens a Context Menu

### DIFF
--- a/tekmate/scenes.py
+++ b/tekmate/scenes.py
@@ -4,6 +4,7 @@ from taz.game import Scene, Game
 
 from tekmate.ui import PlayerUI, NoteUI, ContextMenuUI
 
+
 class WorldScene(Scene):
     def __init__(self, ident):
         super(WorldScene, self).__init__(ident)
@@ -20,22 +21,107 @@ class WorldScene(Scene):
         self.context_menu = ContextMenuUI()
         self.add_item_to_ui(NoteUI(self.world_container))
 
+    def add_item_to_ui(self, item):
+        self.items_in_ui.append(item)
+
     def update(self):  # pragma: no cover  (This is only because of all the branches, they will get tested eventually)
         for event in self.game.update_context["get_events"]():
             if event.type == pygame.QUIT or self.escape_key_pressed(event):
                 raise Game.GameExitException
             elif self.left_mouse_button_pressed(event):
-                if not self.context_menu.visible:
-                    self.move_player(event.pos, self.display)
-                    self.add_item_if_clicked_on(event.pos)
-                else:
-                    self.interact_with_context_menu(event.pos)
-                    #  self.context_menu.visible = False
+                self.handle_left_mouse_button(pos)
             elif self.right_mouse_button_pressed(event):
-                self.change_context_menu_if_clicked_on_item(event.pos)
-                self.context_menu.show(event.pos, self.display)
+                self.open_context_menu(pos)
             elif self.i_pressed(event):
                 self.handle_bag()
+
+    def escape_key_pressed(self, event):
+        return event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE
+
+    def left_mouse_button_pressed(self, event):
+        return event.type == pygame.MOUSEBUTTONDOWN and event.button == 1
+
+    def handle_left_mouse_button(self, pos):
+        if not self.context_menu.visible:
+            self.move_player(pos, self.display)
+            self.add_item_if_clicked_on(pos)
+        else:
+            self.interact_with_context_menu(pos)
+
+    def move_player(self, mouse_pos, display):
+        self.player_ui.move_player(mouse_pos, display)
+
+    def add_item_if_clicked_on(self, pos):
+        for item_ui in self.items_in_ui:
+            if self.clicked_on(item_ui, pos):
+                self.add_item_to_player(item_ui)
+
+    def clicked_on(self, item, pos):
+        return item.surface.get_rect(topleft=item.position).collidepoint(pos)
+
+    def add_item_to_player(self, item_ui):
+        self.player_ui.add_item(item_ui.item)
+        self.items_in_ui.remove(item_ui)
+
+    def interact_with_context_menu(self, pos):
+        if self.clicked_on(self.context_menu, pos):
+            menu_clicked = self.context_menu.interact_with_item(pos)
+            self.player_ui.interact(menu_clicked)
+        else:
+            self.hide_context_menu()
+
+    def hide_context_menu(self):
+        self.context_menu.visible = False
+
+    def right_mouse_button_pressed(self, event):
+        return event.type == pygame.MOUSEBUTTONDOWN and event.button == 3
+
+    def open_context_menu(self, pos):
+        self.change_context_menu_if_clicked_on_item(pos)
+        self.show_context_menu(pos)
+
+    def change_context_menu_if_clicked_on_item(self, pos):
+        menu_style = ContextMenuUI.CONTEXT_MENU_DEFAULT
+        for item_ui in self.items_in_ui:
+            menu_style = self.change_context_menu_if_necessary(item_ui, pos)
+        self.context_menu.create_menu(menu_style)
+
+    def change_context_menu_if_necessary(self, item_ui, pos):
+        menu_style = ContextMenuUI.CONTEXT_MENU_DEFAULT
+        if self.clicked_on(item_ui, pos):
+            menu_style = ContextMenuUI.CONTEXT_MENU_ITEM
+        if self.is_bag_visible() and self.clicked_on(self.player_ui.bag_ui, pos):
+            menu_style = ContextMenuUI.CONTEXT_MENU_BAG_ITEM
+        return menu_style
+
+    def is_bag_visible(self):
+        return self.player_ui.is_bag_visible()
+
+    def show_context_menu(self, pos):
+        self.context_menu.show(pos, self.display)
+
+    def i_pressed(self, event):
+        return event.type == pygame.KEYDOWN and event.key == pygame.K_i
+
+    def handle_bag(self):
+        self.open_close_bag()
+        if self.is_context_menu_visible():
+            self.hide_context_menu()
+
+    def open_close_bag(self):
+        if not self.is_bag_visible():
+            self.show_bag()
+        else:
+            self.hide_bag()
+
+    def show_bag(self):
+        self.player_ui.show_bag()
+
+    def hide_bag(self):
+        self.player_ui.hide_bag()
+
+    def is_context_menu_visible(self):
+        return self.context_menu.visible
 
     def render(self):  # pragma: no cover
         self.display = self.game.render_context["display"]
@@ -43,14 +129,29 @@ class WorldScene(Scene):
 
         self.render_items()
         self.render_player()
-
-        if self.player_ui.is_bag_visible():
-            self.draw_bag()
-
-        if self.is_context_menu_visible():
-            self.render_context_menu()
+        self.render_bag()
+        self.render_context_menu()
 
         pygame.display.flip()
+
+    def render_items(self):
+        for item in self.items_in_ui:
+            item.render(self.display)
+
+    def render_player(self):
+        self.player_ui.render(self.display)
+
+    def render_bag(self):
+        if self.player_ui.is_bag_visible():
+            self.player_ui.draw_bag(self.game.render_context["display"])
+        else:   # pragma: no cover
+            pass
+
+    def render_context_menu(self):
+        if self.is_context_menu_visible():
+            self.context_menu.render(self.display)
+        else:   # pragma: no cover
+            pass
 
     def resume(self):  # pragma: no cover
         print("Resuming World")
@@ -60,82 +161,3 @@ class WorldScene(Scene):
 
     def tear_down(self):  # pragma: no cover
         print("Tearing-Down World")
-
-    def escape_key_pressed(self, event):
-        return event.type == pygame.KEYDOWN and event.key == pygame.K_ESCAPE
-
-    def left_mouse_button_pressed(self, event):
-        return event.type == pygame.MOUSEBUTTONDOWN and event.button == 1
-
-    def right_mouse_button_pressed(self, event):
-        return event.type == pygame.MOUSEBUTTONDOWN and event.button == 3
-
-    def i_pressed(self, event):
-        return event.type == pygame.KEYDOWN and event.key == pygame.K_i
-
-    def is_bag_visible(self):
-        return self.player_ui.is_bag_visible()
-
-    def show_bag(self):
-        self.player_ui.show_bag()
-
-    def draw_bag(self):
-        self.player_ui.draw_bag(self.game.render_context["display"])
-
-    def hide_bag(self):
-        self.player_ui.hide_bag()
-
-    def move_player(self, mouse_pos, display):
-        self.player_ui.move_player(mouse_pos, display)
-
-    def handle_bag(self):
-        if not self.is_bag_visible():
-            self.show_bag()
-        else:
-            self.hide_bag()
-
-    def add_item_to_ui(self, item):
-        self.items_in_ui.append(item)
-
-    def render_items(self):
-        for item in self.items_in_ui:
-            item.render(self.display)
-
-    def render_player(self):
-        self.player_ui.render(self.display)
-
-    def add_item_if_clicked_on(self, pos):
-        for item_ui in self.items_in_ui:
-            if self.is_clicked_on_item(item_ui, pos):
-                self.add_item_to_player(item_ui.item)
-                self.items_in_ui.remove(item_ui)
-
-    def is_clicked_on_item(self, item, pos):
-        return item.surface.get_rect(topleft=item.position).collidepoint(pos)
-
-    def add_item_to_player(self, item):
-        self.player_ui.add_item(item)
-
-    def is_context_menu_visible(self):
-        return self.context_menu.visible
-
-    def render_context_menu(self):
-        self.context_menu.render(self.display)
-
-    def interact_with_context_menu(self, pos):
-        if self.is_clicked_on_item(self.context_menu, pos):
-            menu_clicked = self.context_menu.interact_with_item(pos)
-            self.player_ui.interact(menu_clicked)
-        else:
-            self.context_menu.visible = False
-
-    def change_context_menu_if_clicked_on_item(self, pos):
-        menu_style = ContextMenuUI.CONTEXT_MENU_DEFAULT
-        for item_ui in self.items_in_ui:
-            if self.is_clicked_on_item(item_ui, pos):
-                if item_ui.item.usable:
-                    menu_style = ContextMenuUI.CONTEXT_MENU_USABLE_ITEM
-                elif item_ui.item.obtainable:
-                    menu_style = ContextMenuUI.CONTEXT_MENU_OBTAINABLE_ITEM
-        self.context_menu.create_menu(menu_style)
-

--- a/tekmate/scenes.py
+++ b/tekmate/scenes.py
@@ -29,9 +29,9 @@ class WorldScene(Scene):
             if event.type == pygame.QUIT or self.escape_key_pressed(event):
                 raise Game.GameExitException
             elif self.left_mouse_button_pressed(event):
-                self.handle_left_mouse_button(pos)
+                self.handle_left_mouse_button(event.pos)
             elif self.right_mouse_button_pressed(event):
-                self.open_context_menu(pos)
+                self.open_context_menu(event.pos)
             elif self.i_pressed(event):
                 self.handle_bag()
 

--- a/tekmate/ui.py
+++ b/tekmate/ui.py
@@ -6,7 +6,7 @@ from os.path import abspath, split, join
 import pygame
 
 from tekmate.game import Player
-from tekmate.items import TelephoneNote
+from tekmate.items import Note
 
 
 class UI(object):
@@ -85,6 +85,8 @@ class PlayerUI(object):
 
     def interact(self, menu_clicked):
         print(menu_clicked)
+        return menu_clicked
+
 
 class BagUI(object):
     BACKGROUND_COLOR = (0, 51, 0)
@@ -95,11 +97,11 @@ class BagUI(object):
         self.surface = pygame.Surface((800, 500))
         self.items_text = []
         self.item_font = pygame.font.SysFont("comicsansms", 72)
+        self.position = (100, 100)
 
     def show_bag(self, player):
         self.visible = True
         self.build_item_text(player.bag)
-
 
     def render(self, display):
         self.surface.fill(self.BACKGROUND_COLOR)
@@ -107,7 +109,7 @@ class BagUI(object):
         for text in self.items_text:
             self.surface.blit(text, (0, y))
             y += 50
-        display.blit(self.surface, (100, 100))
+        display.blit(self.surface, self.position)
 
     def build_item_text(self, bag):
         for item in bag:
@@ -125,8 +127,7 @@ class BagUI(object):
 class ContextMenuUI(object):
     BACKGROUND_COLOR = (190, 190, 190)
     CONTEXT_MENU_DEFAULT = ["Walk"]
-    CONTEXT_MENU_OBTAINABLE_ITEM = ["Look at", "Take"]
-    CONTEXT_MENU_USABLE_ITEM = ["Look at", "Use"]
+    CONTEXT_MENU_ITEM = ["Look at", "Take", "Use"]
     CONTEXT_MENU_BAG_ITEM = ["Inspect", "Select"]
 
     def __init__(self):
@@ -179,7 +180,7 @@ class ContextMenuUI(object):
 class NoteUI(object):
     def __init__(self, parent_container):
         assert parent_container is not None
-        self.item = TelephoneNote(parent_container)
+        self.item = Note(parent_container)
         self.surface = pygame.Surface((150, 200))
         self.image = UI.load_image("prolog", "letter.png")
         self.position = (300, 100)

--- a/tekmate/ui.py
+++ b/tekmate/ui.py
@@ -83,6 +83,8 @@ class PlayerUI(object):
     def add_item(self, item):
         self.player.add_item(item)
 
+    def interact(self, menu_clicked):
+        print(menu_clicked)
 
 class BagUI(object):
     BACKGROUND_COLOR = (0, 51, 0)
@@ -97,6 +99,7 @@ class BagUI(object):
     def show_bag(self, player):
         self.visible = True
         self.build_item_text(player.bag)
+
 
     def render(self, display):
         self.surface.fill(self.BACKGROUND_COLOR)
@@ -117,6 +120,60 @@ class BagUI(object):
     def hide_bag(self):
         self.visible = False
         self.items_text = []
+
+
+class ContextMenuUI(object):
+    BACKGROUND_COLOR = (190, 190, 190)
+    CONTEXT_MENU_DEFAULT = ["Walk"]
+    CONTEXT_MENU_OBTAINABLE_ITEM = ["Look at", "Take"]
+    CONTEXT_MENU_USABLE_ITEM = ["Look at", "Use"]
+    CONTEXT_MENU_BAG_ITEM = ["Inspect", "Select"]
+
+    def __init__(self):
+        self.visible = False
+        self.menu_items = None
+        self.surface = None
+        self.create_menu(self.CONTEXT_MENU_DEFAULT)
+        self.font = pygame.font.SysFont("arial", 25)
+        self.position = (0, 0)
+
+    def create_menu(self, menu_style):
+        self.menu_items = menu_style
+        height = len(menu_style) * 30
+        self.surface = pygame.Surface((150, height))
+
+    def render(self, display):
+        self.surface.fill(self.BACKGROUND_COLOR)
+        self.render_item_text()
+        display.blit(self.surface, self.position)
+
+    def render_item_text(self):
+        y = 0
+        for item in self.menu_items:
+            text = self.font.render(item, True, (50, 50, 50))
+            self.surface.blit(text, (0, y))
+            y += 30
+
+    def show(self, pos, display):
+        self.visible = True
+        self.position = pos
+
+        if self.is_mouse_pos_clicked_is_furthest_right(pos, display):
+            self.position = (self.position[0]-self.surface.get_width(), self.position[1])
+
+    def is_mouse_pos_clicked_is_furthest_right(self, pos, display):
+        return display.get_width() - pos[0] < self.surface.get_width()
+
+    def hide(self):
+        self.visible = False
+
+    def interact_with_item(self, pos):
+        item = self.get_item_clicked(pos)
+        return item
+
+    def get_item_clicked(self, pos):
+        item_number = int((pos[1] - self.position[1])/30)
+        return self.menu_items[item_number]
 
 
 class NoteUI(object):

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -2,15 +2,15 @@
 from unittest import TestCase
 
 try:
-    from unittest import Mock
+    from unittest import Mock, patch
 except ImportError:
-    from mock import Mock
+    from mock import Mock, patch
 
 import pygame
 from taz.game import Game
 
 from tekmate.scenes import WorldScene
-from tekmate.ui import NoteUI
+from tekmate.ui import NoteUI, ContextMenuUI
 
 
 class WorldSceneUpdateTestCase(TestCase):
@@ -63,14 +63,16 @@ class WorldSceneTestCase(TestCase):
             button = None
             type = pygame.KEYDOWN
             key = key_pressed
+
         return MockEvent()
 
-    def create_mouse_mock(self):
+    def create_mouse_mock(self, button_nr):
         class MockEvent:
             pos = (130, 200)
-            button = 1
+            button = button_nr
             type = pygame.MOUSEBUTTONDOWN
             pygame.key = None
+
         return MockEvent()
 
     def create_item_click(self, pos, item_pos):
@@ -80,33 +82,28 @@ class WorldSceneTestCase(TestCase):
         self.world_scene.add_item_to_ui(item_ui)
         self.world_scene.add_item_if_clicked_on(pos)
 
-    def test_when_mouse_button_is_pressed_function_should_return_true(self):
-        event = self.create_mouse_mock()
-        self.assertTrueTrueFalse(self.world_scene.left_mouse_button_pressed(event),
-                                 self.world_scene.escape_key_pressed(event),
-                                 self.world_scene.i_pressed(event))
+    def setup_note_for_clicked_context_menu(self):
+        note_ui = NoteUI([])
+        self.world_scene.add_item_to_ui(note_ui)
+        note_ui.item.position = (0, 0)
+        return note_ui
 
-    def test_when_escape_key_pressed_function_should_return_true(self):
-        event = self.create_key_mock(pygame.K_ESCAPE)
-        self.assertTrueTrueFalse(self.world_scene.escape_key_pressed(event),
-                                 self.world_scene.left_mouse_button_pressed(event),
-                                 self.world_scene.i_pressed(event))
+    def mock_is_clicked_on_item(self):
+        mock_function = Mock()
+        self.world_scene.clicked_on = mock_function
+        mock_function = True
 
-    def test_when_i_key_pressed_draw_bag(self):
-        event = self.create_key_mock(pygame.K_i)
-        self.assertTrueTrueFalse(self.world_scene.i_pressed(event),
-                                 self.world_scene.left_mouse_button_pressed(event),
-                                 self.world_scene.escape_key_pressed(event))
+    def mock_context_menu(self):
+        mock_context = Mock()
+        self.world_scene.context_menu = mock_context
+        return mock_context
 
-    def assertTrueTrueFalse(self, evt1, evt2, evt3):
-        self.assertTrue(evt1)
-        self.assertFalse(evt2)
-        self.assertFalse(evt3)
-
-    def test_show_bag_should_make_bag_ui_visible(self):
+    def create_setup_click_context_menu(self):
         self.world_scene.initialize_scene()
-        self.world_scene.show_bag()
-        self.assertTrue(self.world_scene.is_bag_visible())
+        self.mock_is_clicked_on_item()
+        mock_context = self.mock_context_menu()
+        note_ui = self.setup_note_for_clicked_context_menu()
+        return mock_context
 
     def setup_mock_game(self):
         mock_game = Mock()
@@ -114,16 +111,55 @@ class WorldSceneTestCase(TestCase):
         self.world_scene.game = mock_game
         return mock_game
 
-    def setup_mock_player_ui(self):
+    def mock_player_ui(self):
         mock_player_ui = Mock()
         self.world_scene.player_ui = mock_player_ui
         return mock_player_ui
 
+    def test_when_left_mouse_button_is_pressed_function_should_return_true(self):
+        event = self.create_mouse_mock(1)
+        self.assertTrueFalseFalseFalse(self.world_scene.left_mouse_button_pressed(event),
+                                       self.world_scene.right_mouse_button_pressed(event),
+                                       self.world_scene.escape_key_pressed(event),
+                                       self.world_scene.i_pressed(event))
+
+    def test_when_mouse_button_is_pressed_function_should_return_true(self):
+        event = self.create_mouse_mock(3)
+        self.assertTrueFalseFalseFalse(self.world_scene.right_mouse_button_pressed(event),
+                                       self.world_scene.left_mouse_button_pressed(event),
+                                       self.world_scene.escape_key_pressed(event),
+                                       self.world_scene.i_pressed(event))
+
+    def test_when_escape_key_pressed_function_should_return_true(self):
+        event = self.create_key_mock(pygame.K_ESCAPE)
+        self.assertTrueFalseFalseFalse(self.world_scene.escape_key_pressed(event),
+                                       self.world_scene.left_mouse_button_pressed(event),
+                                       self.world_scene.right_mouse_button_pressed(event),
+                                       self.world_scene.i_pressed(event))
+
+    def test_when_i_key_pressed_draw_bag(self):
+        event = self.create_key_mock(pygame.K_i)
+        self.assertTrueFalseFalseFalse(self.world_scene.i_pressed(event),
+                                       self.world_scene.left_mouse_button_pressed(event),
+                                       self.world_scene.right_mouse_button_pressed(event),
+                                       self.world_scene.escape_key_pressed(event))
+
+    def assertTrueFalseFalseFalse(self, evt1, evt2, evt3, evt4):
+        self.assertTrue(evt1)
+        self.assertFalse(evt2)
+        self.assertFalse(evt3)
+        self.assertFalse(evt4)
+
+    def test_show_bag_should_make_bag_ui_visible(self):
+        self.world_scene.initialize_scene()
+        self.world_scene.show_bag()
+        self.assertTrue(self.world_scene.is_bag_visible())
+
     def test_draw_bag_should_call_player_uis_draw_bag(self):
-        mock_player_ui = self.setup_mock_player_ui()
+        mock_player_ui = self.mock_player_ui()
         mock_game = self.setup_mock_game()
 
-        self.world_scene.draw_bag()
+        self.world_scene.render_bag()
         mock_player_ui.draw_bag.assert_called_with(mock_game.render_context["display"])
 
     def test_hide_bag_should_make_bag_visible_false(self):
@@ -137,16 +173,23 @@ class WorldSceneTestCase(TestCase):
         self.world_scene.move_player(None, None)
         mock_player_ui.move_player.assert_called_with(None, None)
 
-    def test_show_bag_if_handle_bag_is_called_and_not_bag_visible(self):
+    def test_when_handle_bag_is_called_and_bag_invisible_show_bag(self):
         self.world_scene.initialize_scene()
         self.world_scene.handle_bag()
         self.assertTrue(self.world_scene.is_bag_visible())
 
-    def test_hide_bag_if_handle_bag_is_called_and_bag_visible(self):
+    def test_when_handle_bag_is_called_and_bag_visible_hide_bag(self):
         self.world_scene.initialize_scene()
         self.world_scene.show_bag()
         self.world_scene.handle_bag()
         self.assertFalse(self.world_scene.is_bag_visible())
+
+    def test_when_handle_bag_is_called_and_context_menu_visible_hide_it(self):
+        self.world_scene.initialize_scene()
+        self.world_scene.display = Mock()
+        self.world_scene.context_menu.visible = True
+        self.world_scene.handle_bag()
+        self.assertFalse(self.world_scene.is_context_menu_visible())
 
     def test_when_called_render_items_every_item_sjould_be_rendered(self):
         mock_item_list = [Mock()]
@@ -176,6 +219,87 @@ class WorldSceneTestCase(TestCase):
     def test_when_clicked_on_an_item_return_true_from_is_clicked_on_item_otherwise_false(self):
         item_ui = NoteUI([])
         item_ui.position = (100, 100)
-        self.assertFalse(self.world_scene.is_clicked_on_item(item_ui, (0, 0)))
+        self.assertFalse(self.world_scene.clicked_on(item_ui, (0, 0)))
         item_ui.position = (0, 0)
-        self.assertTrue(self.world_scene.is_clicked_on_item(item_ui, (10, 10)))
+        self.assertTrue(self.world_scene.clicked_on(item_ui, (10, 10)))
+
+    def test_context_menu_should_be_invisible_by_default(self):
+        self.world_scene.initialize_scene()
+        self.assertFalse(self.world_scene.is_context_menu_visible())
+
+    def test_when_context_menu_is_visible_render_context_menu_should_call_render_function_of_context_menu(self):
+        self.world_scene.initialize_scene()
+        mock_context_menu = Mock()
+        self.world_scene.display = None
+        self.world_scene.context_menu = mock_context_menu
+        self.world_scene.render_context_menu()
+        mock_context_menu.render.assert_called_with(None)
+
+    def test_when_clicked_on_context_menu_call_respective_interaction(self):
+        mock_function = Mock()
+
+        self.world_scene.initialize_scene()
+        self.world_scene.clicked_on = mock_function
+        mock_function = True
+        mock_player = Mock()
+
+        self.world_scene.player_ui = mock_player
+        self.world_scene.interact_with_context_menu((0, 0))
+        mock_player.interact.assert_called_with('Walk')
+
+    def test_when_clicked_on_space_while_context_menu_is_open_visible_is_false(self):
+        mock_function = Mock()
+        self.world_scene.initialize_scene()
+        self.world_scene.context_menu.visible = True
+        self.world_scene.interact_with_context_menu((10000, 10000))
+        self.assertFalse(self.world_scene.context_menu.visible)
+
+    def test_when_right_clicked_on_usable_item_open_menu_usable_context_menu(self):
+        mock_context = self.create_setup_click_context_menu()
+
+        self.world_scene.change_context_menu_if_clicked_on_item((10, 10))
+        mock_context.create_menu.assert_called_with(ContextMenuUI.CONTEXT_MENU_ITEM)
+
+    def test_when_right_clicked_on_obtainable_item_open_menu_obtainable_context_menu(self):
+        mock_context = self.create_setup_click_context_menu()
+        self.world_scene.change_context_menu_if_clicked_on_item((10, 10))
+        mock_context.create_menu.assert_called_with(ContextMenuUI.CONTEXT_MENU_ITEM)
+
+    def test_when_right_clicked_with_bag_open_and_inside_bag_open_context_menu_bag_item(self):
+        self.world_scene.initialize_scene()
+        self.world_scene.show_bag()
+
+        mock_context = self.mock_context_menu()
+        note_ui = self.setup_note_for_clicked_context_menu()
+
+        self.world_scene.change_context_menu_if_clicked_on_item((100, 100))
+        mock_context.create_menu.assert_called_with(ContextMenuUI.CONTEXT_MENU_BAG_ITEM)
+
+    @patch("tekmate.scenes.WorldScene.move_player")
+    def test_when_context_menu_is_not_visible_handle_left_mouse_button_should_move_player_or_add_item(self, mock_move_player):
+        self.world_scene.initialize_scene()
+        self.world_scene.handle_left_mouse_button((10, 10))
+        mock_move_player.assert_called_with((10, 10), None)
+
+    @patch("tekmate.scenes.WorldScene.interact_with_context_menu")
+    def test_when_context_menu_is_vibisle_left_click_should_interact_with_context_menu(self, mock_interact):
+        self.world_scene.initialize_scene()
+        self.world_scene.context_menu.visible = True
+        self.world_scene.handle_left_mouse_button((10, 10))
+        mock_interact.assert_called_with((10, 10))
+
+    @patch("tekmate.ui.ContextMenuUI.show")
+    def test_when_show_context_menu_is_called_context_menu_should_be_visible(self, mock_show_cont_ui):
+        self.world_scene.initialize_scene()
+        self.world_scene.show_context_menu((10, 10))
+        mock_show_cont_ui.assert_called_with((10, 10), None)
+
+    @patch("tekmate.scenes.WorldScene.show_context_menu")
+    def test_when_open_context_menu_is_called_it_should_call_show_context_menu_eventually(self, mock_show):
+        self.world_scene.initialize_scene()
+        self.world_scene.open_context_menu((10, 10))
+        mock_show.assert_called_with((10, 10))
+
+
+
+

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -4,7 +4,7 @@ from unittest import TestCase, skip
 from mock import patch, call, Mock
 from pygame import Surface, display
 
-from tekmate.ui import UI, PlayerUI, BagUI, NoteUI
+from tekmate.ui import UI, PlayerUI, BagUI, NoteUI, ContextMenuUI
 from tekmate.game import Player
 from tekmate.items import Note, IdCard
 
@@ -124,8 +124,6 @@ class BagUITestCase(TestCase):
         self.assertEqual(len(self.bag_ui.items_text), 0)
 
 
-
-
 class NoteUITestCase(TestCase):
     def setUp(self):
         self.note_ui = NoteUI([])
@@ -154,3 +152,42 @@ class NoteUITestCase(TestCase):
         self.note_ui.render(mock_display)
         mock_surface.blit.assert_called_with(mock_image, (0, 0))
         mock_display.blit.assert_called_with(mock_surface, (300, 100))
+
+
+class ContextMenuUITestCase(TestCase):
+    def setUp(self):
+        menu_items = ["One", "Two", "Three"]
+        self.context_menu = ContextMenuUI(menu_items)
+
+    def test_visible_defaults_to_false(self):
+        self.assertFalse(self.context_menu.visible)
+
+    def test_when_creating_menu_items_container_should_not_be_none(self):
+        self.assertIsNotNone(self.context_menu.menu_items)
+
+    def test_when_creating_and_menu_items_are_none_raise_exception(self):
+        with self.assertRaises(AssertionError):
+            ContextMenuUI(None)
+
+    def test_when_creating_surface_should_not_be_none(self):
+        self.assertIsNotNone(self.context_menu.surface)
+
+    def test_when_creating_font_should_be_initialised_and_not_none(self):
+        self.assertIsNotNone(self.context_menu.font)
+
+    def test_when_three_items_in_list_height_should_be_three_times_thirty_pixels(self):
+        self.assertEqual(self.context_menu.surface.get_height(), 90)
+
+    def test_when_should_drawn_then_surface_is_filled_with_background_color(self):
+        mock_surface = Mock()
+        self.context_menu.surface = mock_surface
+        self.context_menu.render(Mock())
+        mock_surface.fill.assert_called_with(ContextMenuUI.BACKGROUND_COLOR)
+
+    def test_when_context_menu_should_be_shown_visible_is_set_true(self):
+        self.context_menu.show((-10, 0))
+        self.assertTrue(self.context_menu.visible)
+
+    def test_when_context_menu_should_be_hidden_visible_is_set_false(self):
+        self.context_menu.hide()
+        self.assertFalse(self.context_menu.visible)

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -71,10 +71,12 @@ class PlayerUITestCase(TestCase):
         self.player_ui.hide_bag()
         self.assertFalse(self.player_ui.is_bag_visible())
 
-
     def test_add_item_adds_an_item_to_the_players_bag(self):
         self.player_ui.add_item(Mock())
         self.assertEqual(len(self.player_ui.player.bag), 1)
+
+    def test_when_interacted_print_message(self):
+        self.assertEqual(self.player_ui.interact("Look at"), "Look at")
 
 
 class BagUITestCase(TestCase):
@@ -156,18 +158,13 @@ class NoteUITestCase(TestCase):
 
 class ContextMenuUITestCase(TestCase):
     def setUp(self):
-        menu_items = ["One", "Two", "Three"]
-        self.context_menu = ContextMenuUI(menu_items)
+        self.context_menu = ContextMenuUI()
 
     def test_visible_defaults_to_false(self):
         self.assertFalse(self.context_menu.visible)
 
     def test_when_creating_menu_items_container_should_not_be_none(self):
         self.assertIsNotNone(self.context_menu.menu_items)
-
-    def test_when_creating_and_menu_items_are_none_raise_exception(self):
-        with self.assertRaises(AssertionError):
-            ContextMenuUI(None)
 
     def test_when_creating_surface_should_not_be_none(self):
         self.assertIsNotNone(self.context_menu.surface)
@@ -176,6 +173,7 @@ class ContextMenuUITestCase(TestCase):
         self.assertIsNotNone(self.context_menu.font)
 
     def test_when_three_items_in_list_height_should_be_three_times_thirty_pixels(self):
+        self.context_menu.create_menu(ContextMenuUI.CONTEXT_MENU_ITEM)
         self.assertEqual(self.context_menu.surface.get_height(), 90)
 
     def test_when_should_drawn_then_surface_is_filled_with_background_color(self):
@@ -185,9 +183,14 @@ class ContextMenuUITestCase(TestCase):
         mock_surface.fill.assert_called_with(ContextMenuUI.BACKGROUND_COLOR)
 
     def test_when_context_menu_should_be_shown_visible_is_set_true(self):
-        self.context_menu.show((-10, 0))
+        self.context_menu.show((-10, 0), display.get_surface())
         self.assertTrue(self.context_menu.visible)
 
     def test_when_context_menu_should_be_hidden_visible_is_set_false(self):
         self.context_menu.hide()
         self.assertFalse(self.context_menu.visible)
+
+    def test_when_context_menu_is_opened_too_far_right_open_it_left_handed(self):
+        self.context_menu.show((1910, 0), Surface((1920, 0)))
+        expected_pos = (1910-self.context_menu.surface.get_width(), 0)
+        self.assertEqual(self.context_menu.position, expected_pos)


### PR DESCRIPTION
- #31 - Right clicking now opens a context menu, which is different for items in space, items in bags and free space of the map.
- The context menu closes, when the bag is opened, as well as when left clicking in free space
- At the moment the only functionality of the Context-Menu is printing the respective label.


This pull request is to make sure everything works with the new item-system


TODO: Implementation of the actual features when clicking a button of the context menu.